### PR TITLE
Telegraf source url for RedHat System is updated for amazon linux

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -29,7 +29,7 @@
   yum_repository:
     name: influxdb
     description: InfluxDB Repository - RHEL $releasever
-    baseurl: https://repos.influxdata.com/rhel/$releasever/$basearch/stable
+    baseurl: https://repos.influxdata.com/rhel/{{ ansible_distribution_major_version }}/$basearch/stable
     gpgcheck: yes
     gpgkey: https://repos.influxdata.com/influxdb.key
 


### PR DESCRIPTION
using {{ ansible_distribution_major_version }} in place of $releasever